### PR TITLE
Slå sammen identiske utbetalingsperioder

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/iverksett/infrastruktur/transformer/TilkjentYtelseDtoToDomain.kt
+++ b/src/main/kotlin/no/nav/dagpenger/iverksett/infrastruktur/transformer/TilkjentYtelseDtoToDomain.kt
@@ -15,13 +15,35 @@ fun TilkjentYtelseDto.toDomain(): TilkjentYtelse {
     )
 }
 
-fun Iterable<UtbetalingDto>.tilTilkjentYtelse(): TilkjentYtelse? {
-    val andeler = this.map { it.toDomain() }
+fun List<UtbetalingDto>.tilTilkjentYtelse(): TilkjentYtelse? {
+    val andeler = this.sammenslått().map { it.toDomain() }
 
     return when (andeler.size) {
         0 -> null
         else -> TilkjentYtelse(andelerTilkjentYtelse = andeler)
     }
+}
+
+fun List<UtbetalingDto>.sammenslått(): List<UtbetalingDto> {
+    return this.sortedBy { it.fraOgMedDato }.fold(emptyList()) { utbetalinger, utbetaling ->
+        if (utbetalinger.isEmpty()) {
+            return@fold listOf(utbetaling)
+        }
+
+        val last = utbetalinger.last()
+
+        if (utbetaling.kanSlåsSammen(last))
+            utbetalinger.dropLast(1) + listOf(last.copy(tilOgMedDato = utbetaling.tilOgMedDato))
+        else
+            utbetalinger + listOf(utbetaling)
+    }
+}
+
+private fun UtbetalingDto.kanSlåsSammen(forrige: UtbetalingDto): Boolean {
+    return this.belopPerDag == forrige.belopPerDag
+            && this.stonadstype == forrige.stonadstype
+            && this.ferietillegg == forrige.ferietillegg
+            && this.fraOgMedDato == forrige.tilOgMedDato.plusDays(1)
 }
 
 fun ForrigeIverksettingDto.tilVedtaksdetaljer(): VedtaksdetaljerDagpenger {

--- a/src/test/kotlin/no/nav/dagpenger/iverksett/infrastruktur/transformer/TilkjentYtelseDtoToDomainKtTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/iverksett/infrastruktur/transformer/TilkjentYtelseDtoToDomainKtTest.kt
@@ -1,0 +1,194 @@
+package no.nav.dagpenger.iverksett.infrastruktur.transformer
+
+import no.nav.dagpenger.iverksett.januar
+import no.nav.dagpenger.iverksett.konsumenter.økonomi.lagUtbetalingDto
+import no.nav.dagpenger.kontrakter.felles.StønadType
+import no.nav.dagpenger.kontrakter.iverksett.Ferietillegg
+import no.nav.dagpenger.kontrakter.iverksett.UtbetalingDto
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class TilkjentYtelseDtoToDomainKtTest {
+
+    @Test
+    fun `slår sammen tom liste med utbetalinger`() {
+        val utbetalinger = emptyList<UtbetalingDto>().sammenslått()
+
+        assertEquals(0, utbetalinger.size)
+    }
+
+    @Test
+    fun `slår sammen liste med 1 utbetaling`() {
+        val utbetalinger = listOf(lagUtbetalingDto(beløp = 100)).sammenslått()
+
+        assertEquals(1, utbetalinger.size)
+        assertEquals(100, utbetalinger.first().belopPerDag)
+    }
+
+    @Test
+    fun `slår sammen to like endagsutbetalinger hvor fom og tom er ved siden av hverandre`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(beløp = 100, fraOgMed = 1.januar(2023), tilOgMed = 1.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 2.januar(2023), tilOgMed = 2.januar(2023))
+        ).sammenslått()
+
+        assertEquals(1, utbetalinger.size)
+        utbetalinger.first().let {
+            assertEquals(1.januar(2023), it.fraOgMedDato)
+            assertEquals(2.januar(2023), it.tilOgMedDato)
+        }
+    }
+
+    @Test
+    fun `slår sammen to like utbetalinger hvor fom og tom er ved siden av hverandre`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(beløp = 100, fraOgMed = 1.januar(2023), tilOgMed = 10.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 11.januar(2023), tilOgMed = 20.januar(2023))
+        ).sammenslått()
+
+        assertEquals(1, utbetalinger.size)
+        utbetalinger.first().let {
+            assertEquals(1.januar(2023), it.fraOgMedDato)
+            assertEquals(20.januar(2023), it.tilOgMedDato)
+        }
+    }
+
+    @Test
+    fun `slår sammen en rapporteringsperiode`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(beløp = 100, fraOgMed = 2.januar(2023), tilOgMed = 2.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 3.januar(2023), tilOgMed = 3.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 4.januar(2023), tilOgMed = 4.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 5.januar(2023), tilOgMed = 5.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 6.januar(2023), tilOgMed = 6.januar(2023)),
+            lagUtbetalingDto(beløp = 0, fraOgMed = 7.januar(2023), tilOgMed = 7.januar(2023)),
+            lagUtbetalingDto(beløp = 0, fraOgMed = 8.januar(2023), tilOgMed = 8.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 9.januar(2023), tilOgMed = 9.januar(2023)),
+            lagUtbetalingDto(beløp = 200, fraOgMed = 10.januar(2023), tilOgMed = 10.januar(2023)),
+            lagUtbetalingDto(beløp = 200, fraOgMed = 11.januar(2023), tilOgMed = 11.januar(2023)),
+            lagUtbetalingDto(beløp = 200, fraOgMed = 12.januar(2023), tilOgMed = 12.januar(2023)),
+            lagUtbetalingDto(beløp = 200, fraOgMed = 13.januar(2023), tilOgMed = 13.januar(2023)),
+        ).sammenslått()
+
+        assertEquals(4, utbetalinger.size)
+        utbetalinger.component1().let {
+            assertEquals(100, it.belopPerDag)
+            assertEquals(2.januar(2023), it.fraOgMedDato)
+            assertEquals(6.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component2().let {
+            assertEquals(0, it.belopPerDag)
+            assertEquals(7.januar(2023), it.fraOgMedDato)
+            assertEquals(8.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component3().let {
+            assertEquals(100, it.belopPerDag)
+            assertEquals(9.januar(2023), it.fraOgMedDato)
+            assertEquals(9.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component4().let {
+            assertEquals(200, it.belopPerDag)
+            assertEquals(10.januar(2023), it.fraOgMedDato)
+            assertEquals(13.januar(2023), it.tilOgMedDato)
+        }
+    }
+
+    @Test
+    fun `slår ikke sammen utbetalinger med mellomrom`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(beløp = 100, fraOgMed = 2.januar(2023), tilOgMed = 2.januar(2023)),
+            lagUtbetalingDto(beløp = 100, fraOgMed = 4.januar(2023), tilOgMed = 4.januar(2023))
+        ).sammenslått()
+
+        assertEquals(2, utbetalinger.size)
+        utbetalinger.first().let {
+            assertEquals(2.januar(2023), it.fraOgMedDato)
+            assertEquals(2.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component2().let {
+            assertEquals(4.januar(2023), it.fraOgMedDato)
+            assertEquals(4.januar(2023), it.tilOgMedDato)
+        }
+    }
+
+    @Test
+    fun `slår ikke sammen utbetalinger med forskjellige beløp`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(beløp = 100, fraOgMed = 2.januar(2023), tilOgMed = 2.januar(2023)),
+            lagUtbetalingDto(beløp = 200, fraOgMed = 3.januar(2023), tilOgMed = 3.januar(2023))
+        ).sammenslått()
+
+        assertEquals(2, utbetalinger.size)
+        utbetalinger.first().let {
+            assertEquals(100, it.belopPerDag)
+            assertEquals(2.januar(2023), it.fraOgMedDato)
+            assertEquals(2.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component2().let {
+            assertEquals(200, it.belopPerDag)
+            assertEquals(3.januar(2023), it.fraOgMedDato)
+            assertEquals(3.januar(2023), it.tilOgMedDato)
+        }
+    }
+
+    @Test
+    fun `slår ikke sammen utbetalinger med forskjellige stønadstyper`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(
+                beløp = 100,
+                fraOgMed = 2.januar(2023),
+                tilOgMed = 2.januar(2023),
+                stønadstype = StønadType.DAGPENGER_ARBEIDSSOKER_ORDINAER
+            ),
+            lagUtbetalingDto(
+                beløp = 100,
+                fraOgMed = 3.januar(2023),
+                tilOgMed = 3.januar(2023),
+                stønadstype = StønadType.DAGPENGER_EOS
+            )
+        ).sammenslått()
+
+        assertEquals(2, utbetalinger.size)
+        utbetalinger.first().let {
+            assertEquals(StønadType.DAGPENGER_ARBEIDSSOKER_ORDINAER, it.stonadstype)
+            assertEquals(2.januar(2023), it.fraOgMedDato)
+            assertEquals(2.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component2().let {
+            assertEquals(StønadType.DAGPENGER_EOS, it.stonadstype)
+            assertEquals(LocalDate.of(2023, 1, 3), it.fraOgMedDato)
+            assertEquals(LocalDate.of(2023, 1, 3), it.tilOgMedDato)
+        }
+    }
+
+    @Test
+    fun `slår ikke sammen utbetalinger med forskjellige ferietillegg`() {
+        val utbetalinger = listOf(
+            lagUtbetalingDto(
+                beløp = 100,
+                fraOgMed = 2.januar(2023),
+                tilOgMed = 2.januar(2023),
+                ferietillegg = Ferietillegg.ORDINAER
+            ),
+            lagUtbetalingDto(
+                beløp = 100,
+                fraOgMed = 3.januar(2023),
+                tilOgMed = 3.januar(2023),
+                ferietillegg = Ferietillegg.AVDOD
+            )
+        ).sammenslått()
+
+        assertEquals(2, utbetalinger.size)
+        utbetalinger.first().let {
+            assertEquals(Ferietillegg.ORDINAER, it.ferietillegg)
+            assertEquals(2.januar(2023), it.fraOgMedDato)
+            assertEquals(2.januar(2023), it.tilOgMedDato)
+        }
+        utbetalinger.component2().let {
+            assertEquals(Ferietillegg.AVDOD, it.ferietillegg)
+            assertEquals(LocalDate.of(2023, 1, 3), it.fraOgMedDato)
+            assertEquals(LocalDate.of(2023, 1, 3), it.tilOgMedDato)
+        }
+    }
+}


### PR DESCRIPTION
En identisk periode her har samme beløp, ferietillegg og stønadstype. I tillegg må periodene være ved siden av hverandre, dvs. så må tom på den ene og fom på den andre ha en diff på nøyaktig ett døgn.