### PR TITLE
Oppgrader Spring Boot til 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.1.8</version>
+        <version>3.2.2</version>
     </parent>
 
     <groupId>no.nav.dagpenger</groupId>
@@ -31,12 +31,8 @@
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <mockk.version>1.13.9</mockk.version>
         <cucumber.version>7.15.0</cucumber.version>
-        <nav.security.token.version>3.0.4</nav.security.token.version>
+        <nav.security.token.version>3.2.0</nav.security.token.version>
         <unleash.version>9.2.0</unleash.version>
-
-        <!-- Overstyring av spring-avhengigheter -->
-        <okhttp3.version>4.9.1</okhttp3.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
     </properties>
 
     <repositories>
@@ -75,7 +71,7 @@
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -89,12 +85,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jetty</artifactId>
-        </dependency>
-        <!-- https://github.com/spring-projects/spring-boot/issues/33044#issuecomment-1379812611 -->
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -190,12 +181,6 @@
         </dependency>
 
         <!-- Test -->
-        <dependency>
-            <groupId>dev.akkinoc.spring.boot</groupId>
-            <artifactId>logback-access-spring-boot-starter</artifactId>
-            <version>4.1.1</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>


### PR DESCRIPTION
- Trenger ikke lenger å nedgradere Jetty, så kan bruke innebygd jetty 12.0.5 gjennom spring-boot-starter-jetty
- logback-access-spring-boot-starter gjorde at appen ikke klarte å starte opp fordi den ikke fant en bønne. Tror ikke vi egentlig bruker denne, så fjernet den
- Trenger ikke lenger overstyre okhttp3 og snakeyaml, disse har innebygd versjon 4.12 og 2.2 hhv.